### PR TITLE
Use XDG_RUNTIME_DIR environment variable (when available) to set temporary user home

### DIFF
--- a/firewarden
+++ b/firewarden
@@ -84,7 +84,11 @@ app_opts() {
 build_dir() {
     # If the jail is being used for a local file, build a temporary directory
     # to function as the jail's home and copy the requested file into it.
-    dir=/tmp/$USER/firewarden/$now
+    if [ -n "$XDG_RUNTIME_DIR" ]; then
+        dir=$XDG_RUNTIME_DIR/firewarden/$now
+    else
+        dir=/tmp/$USER/firewarden/$now
+    fi
     mkdir -p "$dir"
     cp "$file_path" "$dir"
 }


### PR DESCRIPTION
The XDG Base Directory spec states that this variable should be used for "user-specific runtime files and other file objects".

https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

Using it also helps ensure that no other unpriveleged users read or change the data in the jail, which is possible when the jail is built in `/tmp/`.