### PR TITLE
Add fault tolerance for older versions of firejail

### DIFF
--- a/firewarden
+++ b/firewarden
@@ -114,7 +114,7 @@ file_check() {
 }
 
 execute() {
-    /usr/bin/firejail --private-cache --private-srv=firewarden-"$now" --private-opt=firewarden-"$now" $homeopt $netopt $devopt "$app" "${appopt[@]}" "${finalargs[@]}"
+    /usr/bin/firejail $private_cache --private-srv=firewarden-"$now" --private-opt=firewarden-"$now" $homeopt $netopt $devopt "$app" "${appopt[@]}" "${finalargs[@]}"
 }
 
 cleanup() {
@@ -204,6 +204,11 @@ if [ -n "$use_config" ]; then
     elif [ -n "$HOME" ] && [ -r "$HOME/.config/firewarden/$app_basename.sh" ]; then
         FIREWARDEN_HOME=$dir FIREWARDEN_FILE=$file_name "$HOME/.config/firewarden/$app_basename.sh"
     fi
+fi
+
+private_cache="--private-cache"
+if [ "$(/usr/bin/firejail --private-cache 2>&1)" == "Error: invalid --private-cache command line option" ]; then
+    private_cache=""
 fi
 
 execute


### PR DESCRIPTION
First of all, thanks for this script. It's really convenient!

Unfortunately, the version of firejail in the Ubuntu package manager (at least for LTS) is pretty old (over a year old now) and doesn't support the --private-cache flag. This pull request omits that flag if firejail does not support it.

Note: I considered comparing the version number and checking if it's >=0.9.56, but this approach gets more directly to the point. I'm sure there are dozens of ways this could be accomplished, and I'm happy to change this PR however you prefer. Just let me know.