### PR TITLE
disable further access to /media and /mnt

### DIFF
--- a/firewarden
+++ b/firewarden
@@ -115,7 +115,7 @@ file_check() {
 }
 
 execute() {
-    /usr/bin/firejail --private-srv=firewarden-"$now" --private-opt=firewarden-"$now" $quiet $homeopt $netopt $devopt "$app" "${appopt[@]}" "${finalargs[@]}"
+    /usr/bin/firejail --disable-mnt --private-srv=firewarden-"$now" --private-opt=firewarden-"$now" $quiet $homeopt $netopt $devopt "$app" "${appopt[@]}" "${finalargs[@]}"
 }
 
 cleanup() {


### PR DESCRIPTION
Allowing access to a single dedicated file on /media but preventing further access to the path.
"--disable-mnt" -option disables both /media and /mnt (for enhanced strictness).
[Change in line 118]